### PR TITLE
fix NPE Update SerialHelper.java

### DIFF
--- a/serialport/src/main/java/tp/xmaihh/serialport/SerialHelper.java
+++ b/serialport/src/main/java/tp/xmaihh/serialport/SerialHelper.java
@@ -111,7 +111,9 @@ public abstract class SerialHelper {
 //                    }
 
                 } catch (Throwable e) {
-                    Log.e("error", e.getMessage());
+                     if (e.getMessage() != null) {
+                        Log.e("error", e.getMessage());
+                    }
                     return;
                 }
             }


### PR DESCRIPTION
FIX java.lang.NullPointerException: println needs a message at android.util.Log.println_native(Native Method) at android.util.Log.e(Log.java:236) at tp.xmaihh.serialport.SerialHelper$ReadThread.run(SerialHelper.java:114) 

[https://github.com/xmaihh/Android-Serialport/issues/45](https://github.com/xmaihh/Android-Serialport/issues/45)