### PR TITLE
Add support for 16KB page size on recent Android versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdk 34
+    compileSdk = libs.versions.maxSdk.get().toInteger()
+
     defaultConfig {
         applicationId "com.ex.serialport"
-        minSdk 14
-        targetSdk 34
-        versionCode gitVersionCode
-        versionName gitVersionName
+        minSdk = libs.versions.minSdk.get().toInteger()
+        targetSdk = libs.versions.maxSdk.get().toInteger()
+        versionCode = gitVersionCode
+        versionName = gitVersionName
     }
     buildTypes {
         release {
@@ -15,6 +16,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.ex.serialport'
     android.applicationVariants.configureEach { variant ->
         variant.outputs.configureEach { output ->
             def fileName = "AndroidSerialportSample-${defaultConfig.versionCode}_${defaultConfig.versionName}.apk"
@@ -30,6 +32,5 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
     implementation 'com.github.CymChad:BaseRecyclerViewAdapterHelper:3.0.7'
     implementation project(path: ':serialport')
-//    implementation 'io.github.xmaihh:serialport:2.1.2'
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ex.serialport">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         maven { url = uri("https://jitpack.io") }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'org.ajoberstar.grgit:grgit-gradle:5.2.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useDeprecatedNdk=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,4 @@
+[versions]
+ndk="29.0.14206865"
+minSdk = "21"
+maxSdk = "36"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 21 10:59:24 CST 2022
+#Tue Feb 03 14:07:25 CET 2026
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/serialport/CMakeLists.txt
+++ b/serialport/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10...3.27)
 
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.

--- a/serialport/build.gradle
+++ b/serialport/build.gradle
@@ -1,13 +1,15 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 34
+    compileSdk = libs.versions.maxSdk.get().toInteger()
+
+    ndkVersion = libs.versions.ndk.get()
 
     defaultConfig {
-        minSdk 14
-        targetSdk 34
-        versionCode 13
-        versionName "2.1.2"
+        minSdk = libs.versions.minSdk.get().toInteger()
+        targetSdk = libs.versions.maxSdk.get().toInteger()
+        versionCode = gitVersionCode
+        versionName = gitVersionName
     }
 
     buildTypes {
@@ -22,5 +24,6 @@ android {
             path "CMakeLists.txt"
         }
     }
+    namespace 'tp.xmaihh.serialport'
 }
 

--- a/serialport/src/main/AndroidManifest.xml
+++ b/serialport/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tp.xmaihh.serialport" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/serialport/src/main/jni/SerialPort.c
+++ b/serialport/src/main/jni/SerialPort.c
@@ -14,8 +14,20 @@
  * limitations under the License.
  */
 
-//#include <termios.h>
-#include <asm/termios.h>
+
+/*
+ * Modifications (2026):
+ * - Added missing ioctl/errno includes
+ * - Enforced RAW mode and deterministic VMIN/VTIME behavior
+ * - Corrected software flow control flags
+ * - Added cold-boot robustness: flush + optional DTR/RTS toggle
+ * - Improved logging and error checking of TCGETS2/TCSETS2
+ *
+ * Author: Nicolás Mahnic Garcia <https://github.com/nmahnic>
+ */
+
+
+#include <asm/termios.h>     // termios2 + TCGETS2/TCSETS2 for BOTHER baudrates
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -23,14 +35,83 @@
 #include <string.h>
 #include <jni.h>
 
-#include "SerialPort.h"
+#include <sys/ioctl.h>       // ioctl()
+#include <errno.h>           // errno
+#include <android/log.h>
 
-#include "android/log.h"
+// For TIOCMGET/TIOCMSET and modem-control bits (DTR/RTS).
+// On some NDKs, these are available via sys/ioctl.h already, but this helps portability.
+#include <linux/tty.h>
+
+#include "SerialPort.h"
 
 static const char *TAG = "serial_port";
 #define LOGI(fmt, args...) __android_log_print(ANDROID_LOG_INFO,  TAG, fmt, ##args)
 #define LOGD(fmt, args...) __android_log_print(ANDROID_LOG_DEBUG, TAG, fmt, ##args)
 #define LOGE(fmt, args...) __android_log_print(ANDROID_LOG_ERROR, TAG, fmt, ##args)
+
+/*
+ * Cold-boot reliability helpers
+ *
+ * SERIALPORT_TOGGLE_DTR_RTS:
+ *   When enabled, the code pulses DTR/RTS (LOW -> HIGH) after configuration.
+ *   This has been observed to "wake" or "reset" certain UART-attached modules
+ *   that remain unresponsive after a full power cycle.
+ *
+ * If the upstream project prefers to keep behavior unchanged by default,
+ * consider setting this to 0 and exposing a Java-side option.
+ */
+#ifndef SERIALPORT_TOGGLE_DTR_RTS
+#define SERIALPORT_TOGGLE_DTR_RTS 1
+#endif
+
+#ifndef SERIALPORT_DTR_RTS_LOW_US
+#define SERIALPORT_DTR_RTS_LOW_US  (100 * 1000)   // 100 ms low pulse
+#endif
+
+#ifndef SERIALPORT_DTR_RTS_HIGH_US
+#define SERIALPORT_DTR_RTS_HIGH_US (200 * 1000)   // 200 ms settle time after rising edge
+#endif
+
+/*
+ * Flush both input and output queues for this file descriptor.
+ * This is useful at boot to drop any spurious bytes left by the driver/module.
+ */
+static void serial_flush_all(int fd) {
+    // TCFLSH(TCIOFLUSH) flushes both input and output.
+    int r = ioctl(fd, TCFLSH, TCIOFLUSH);
+    LOGD("TCFLSH(TCIOFLUSH) r=%d errno=%d (%s)", r, errno, strerror(errno));
+}
+
+/*
+ * Toggle DTR/RTS low then high to help modules that need an explicit wake/reset pulse.
+ * Safe to ignore if the platform does not support it; errors are logged and ignored.
+ */
+static void serial_toggle_dtr_rts(int fd) {
+#if SERIALPORT_TOGGLE_DTR_RTS
+    int status = 0;
+
+    int r = ioctl(fd, TIOCMGET, &status);
+    LOGD("TIOCMGET r=%d status=0x%x errno=%d (%s)", r, status, errno, strerror(errno));
+    if (r != 0) return;
+
+    // Drive DTR/RTS low.
+    status &= ~TIOCM_DTR;
+    status &= ~TIOCM_RTS;
+    r = ioctl(fd, TIOCMSET, &status);
+    LOGD("TIOCMSET (LOW) r=%d status=0x%x errno=%d (%s)", r, status, errno, strerror(errno));
+    usleep(SERIALPORT_DTR_RTS_LOW_US);
+
+    // Drive DTR/RTS high.
+    status |= TIOCM_DTR;
+    status |= TIOCM_RTS;
+    r = ioctl(fd, TIOCMSET, &status);
+    LOGD("TIOCMSET (HIGH) r=%d status=0x%x errno=%d (%s)", r, status, errno, strerror(errno));
+    usleep(SERIALPORT_DTR_RTS_HIGH_US);
+#else
+    (void)fd;
+#endif
+}
 
 /*
  * Class:     android_serialport_SerialPort
@@ -39,144 +120,177 @@ static const char *TAG = "serial_port";
  */
 JNIEXPORT jobject JNICALL Java_android_1serialport_1api_SerialPort_open
         (JNIEnv *env, jclass thiz, jstring path, jint baudrate, jint stopBits, jint dataBits,
-         jint parity, jint flowCon, jint flags) {
+                jint parity, jint flowCon, jint flags) {
+
+    (void)thiz;
+
     int fd;
-    speed_t speed;
     jobject mFileDescriptor;
 
-    /* Check arguments */
-    {
-        speed = baudrate;
-        if (speed == -1) {
-            /* TODO: throw an exception */
-            LOGE("Invalid baudrate");
-            return NULL;
-        }
+    // ------------------------------------------------------------------------
+    // 1) Validate arguments
+    // ------------------------------------------------------------------------
+    if (baudrate <= 0) {
+        LOGE("Invalid baudrate: %d", baudrate);
+        return NULL;
     }
 
-    /* Opening device */
+    // ------------------------------------------------------------------------
+    // 2) Open device node
+    // ------------------------------------------------------------------------
     {
         jboolean iscopy;
         const char *path_utf = (*env)->GetStringUTFChars(env, path, &iscopy);
+
         LOGD("Opening serial port %s with flags 0x%x", path_utf, O_RDWR | flags);
         fd = open(path_utf, O_RDWR | flags);
         LOGD("open() fd = %d", fd);
+
         (*env)->ReleaseStringUTFChars(env, path, path_utf);
+
         if (fd == -1) {
-            /* Throw an exception */
-            LOGE("Cannot open port");
-            /* TODO: throw an exception */
+            LOGE("Cannot open port errno=%d (%s)", errno, strerror(errno));
             return NULL;
         }
     }
 
-    /* Configure device */
+    // ------------------------------------------------------------------------
+    // 3) Configure port using termios2 (TCGETS2/TCSETS2)
+    // ------------------------------------------------------------------------
     {
         struct termios2 cfg;
 
-        ioctl (fd, TCGETS2, &cfg);
-        // Set baudrate
-        cfg.c_cflag &= ~CBAUD;
-        cfg.c_cflag |= BOTHER;
+        LOGD("Configuring serial port (enter) fd=%d", fd);
 
-        cfg.c_ispeed = baudrate;
-        cfg.c_ospeed = baudrate;
-
-        cfg.c_cflag &= ~CSIZE;
-        switch (dataBits) {
-            case 5:
-                cfg.c_cflag |= CS5;    //5 Data Bits
-                break;
-            case 6:
-                cfg.c_cflag |= CS6;    //6 Data Bits
-                break;
-            case 7:
-                cfg.c_cflag |= CS7;    //7 Data Bits
-                break;
-            case 8:
-                cfg.c_cflag |= CS8;    //8 Data Bits
-                break;
-            default:
-                cfg.c_cflag |= CS8;
-                break;
+        // 3.1 Get current config (must check return value; cfg is undefined on failure).
+        int r = ioctl(fd, TCGETS2, &cfg);
+        LOGD("TCGETS2 r=%d errno=%d (%s)", r, errno, strerror(errno));
+        if (r != 0) {
+            LOGE("TCGETS2 failed");
+            close(fd);
+            return NULL;
         }
 
+        // 3.2 Enforce RAW mode and deterministic behavior
+        //
+        // Why:
+        //  - Avoid canonical mode and line discipline transformations.
+        //  - Ensure read() does not block indefinitely (VMIN/VTIME).
+        //  - Keep consistent behavior across devices/toolchains.
+        cfg.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL |
+                IXON | IXOFF | IXANY);
+        cfg.c_oflag &= ~OPOST;
+        cfg.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+        cfg.c_cflag |= (CLOCAL | CREAD);
+
+        // Non-blocking-ish read behavior:
+        //  VMIN=0, VTIME=5 => read() returns immediately with available bytes,
+        //  or returns 0 after ~0.5s if no data arrives.
+        cfg.c_cc[VMIN]  = 0;
+        cfg.c_cc[VTIME] = 5;
+
+        // 3.3 Set baudrate (termios2 supports arbitrary rates via BOTHER)
+        cfg.c_cflag &= ~CBAUD;
+        cfg.c_cflag |= BOTHER;
+        cfg.c_ispeed = (speed_t)baudrate;
+        cfg.c_ospeed = (speed_t)baudrate;
+
+        // 3.4 Data bits
+        cfg.c_cflag &= ~CSIZE;
+        switch (dataBits) {
+            case 5: cfg.c_cflag |= CS5; break;
+            case 6: cfg.c_cflag |= CS6; break;
+            case 7: cfg.c_cflag |= CS7; break;
+            case 8:
+            default: cfg.c_cflag |= CS8; break;
+        }
+
+        // 3.5 Parity
         switch (parity) {
-            case 0:
-                cfg.c_cflag &= ~PARENB;    //PARITY OFF
+            case 0: // None
+                cfg.c_cflag &= ~PARENB;
                 break;
-            case 1:
-                cfg.c_cflag |= (PARODD | PARENB);   //PARITY ODD
+            case 1: // Odd
+                cfg.c_cflag |= (PARODD | PARENB);
                 cfg.c_iflag &= ~IGNPAR;
-                cfg.c_iflag |= PARMRK;
-                cfg.c_iflag |= INPCK;
+                cfg.c_iflag |= (PARMRK | INPCK);
                 break;
-            case 2:
-                cfg.c_iflag &= ~(IGNPAR | PARMRK); //PARITY EVEN
+            case 2: // Even
+                cfg.c_iflag &= ~(IGNPAR | PARMRK);
                 cfg.c_iflag |= INPCK;
                 cfg.c_cflag |= PARENB;
                 cfg.c_cflag &= ~PARODD;
                 break;
-            case 3:
-                //  PARITY SPACE
-                cfg.c_iflag &= ~IGNPAR;             //  Make sure wrong parity is not ignored
-                cfg.c_iflag |= PARMRK;              //  Marks parity error, parity error
-                //  is given as three char sequence
-                cfg.c_iflag |= INPCK;               //  Enable input parity checking
-                cfg.c_cflag |= PARENB | CMSPAR;     //  Enable parity and set space parity
-                cfg.c_cflag &= ~PARODD;             //
+            case 3: // Space
+                cfg.c_iflag &= ~IGNPAR;
+                cfg.c_iflag |= (PARMRK | INPCK);
+                cfg.c_cflag |= (PARENB | CMSPAR);
+                cfg.c_cflag &= ~PARODD;
                 break;
-            case 4:
-                //  PARITY MARK
-                cfg.c_iflag &= ~IGNPAR;             //  Make sure wrong parity is not ignored
-                cfg.c_iflag |= PARMRK;              //  Marks parity error, parity error
-                //  is given as three char sequence
-                cfg.c_iflag |= INPCK;               //  Enable input parity checking
-                cfg.c_cflag |= PARENB | CMSPAR | PARODD;
+            case 4: // Mark
+                cfg.c_iflag &= ~IGNPAR;
+                cfg.c_iflag |= (PARMRK | INPCK);
+                cfg.c_cflag |= (PARENB | CMSPAR | PARODD);
                 break;
             default:
                 cfg.c_cflag &= ~PARENB;
                 break;
         }
 
+        // 3.6 Stop bits
         switch (stopBits) {
+            case 2: cfg.c_cflag |= CSTOPB; break;
             case 1:
-                cfg.c_cflag &= ~CSTOPB;    //1 Stop Bit
-                break;
-            case 2:
-                cfg.c_cflag |= CSTOPB;    //2 Stop Bits
-                break;
-            default:
-                cfg.c_cflag &= ~CSTOPB;
-                break;
+            default: cfg.c_cflag &= ~CSTOPB; break;
         }
 
-        // hardware flow control
+        // 3.7 Flow control
+        //
+        // IMPORTANT FIX:
+        //  IXON/IXOFF/IXANY are input flags (c_iflag), not control flags (c_cflag).
+        //  Clear both hardware/software flags first to avoid carrying stale state.
+        cfg.c_cflag &= ~CRTSCTS;
+        cfg.c_iflag &= ~(IXON | IXOFF | IXANY);
+
         switch (flowCon) {
-            case 0:
-                cfg.c_cflag &= ~CRTSCTS;    //No Flow Control
+            case 0: // None
                 break;
-            case 1:
-                cfg.c_cflag |= CRTSCTS;    //Hardware Flow Control
+            case 1: // Hardware RTS/CTS
+                cfg.c_cflag |= CRTSCTS;
                 break;
-            case 2:
-                cfg.c_cflag |= IXON | IXOFF | IXANY;    //Software Flow Control
+            case 2: // Software XON/XOFF
+                cfg.c_iflag |= (IXON | IXOFF | IXANY);
                 break;
             default:
-                cfg.c_cflag &= ~CRTSCTS;
                 break;
         }
 
-
-        if (ioctl(fd, TCSETS2, &cfg)) {
-            LOGE("tcsets2() failed");
+        // 3.8 Apply configuration
+        r = ioctl(fd, TCSETS2, &cfg);
+        LOGD("TCSETS2 r=%d errno=%d (%s)", r, errno, strerror(errno));
+        if (r != 0) {
+            LOGE("TCSETS2 failed");
             close(fd);
-            /* TODO: throw an exception */
             return NULL;
         }
+
+        LOGD("Configuring serial port (done) fd=%d", fd);
+
+        // --------------------------------------------------------------------
+        // 4) Cold-boot robustness (flush + optional DTR/RTS pulse + flush)
+        // --------------------------------------------------------------------
+        // Rationale:
+        //  - Flush any residual bytes before attempting any higher-level protocol.
+        //  - Pulse DTR/RTS to wake/reset certain modules after power cycle.
+        //  - Flush again in case the module emits spurious bytes on wake.
+        serial_flush_all(fd);
+        serial_toggle_dtr_rts(fd);
+        serial_flush_all(fd);
     }
 
-    /* Create a corresponding file descriptor */
+    // ------------------------------------------------------------------------
+    // 5) Build and return java.io.FileDescriptor wrapping the native fd
+    // ------------------------------------------------------------------------
     {
         jclass cFileDescriptor = (*env)->FindClass(env, "java/io/FileDescriptor");
         jmethodID iFileDescriptor = (*env)->GetMethodID(env, cFileDescriptor, "<init>", "()V");


### PR DESCRIPTION
Main changes:

Build & configuration:
	•	Updated Gradle wrapper and Android Gradle Plugin to recent versions
	•	Migrated SDK and NDK versions to version catalog (libs.versions.toml)
	•	Updated compileSdk, targetSdk, and minSdk handling
	•	Removed deprecated package attribute from AndroidManifest in favor of namespace
	•	Ensured the native library can be built with modern NDK versions
	•	minSdk updated to 21
	•	CMake updated to at least 3.10…3.27

These changes allow the library to build and run correctly on devices using the new 16KB page size introduced in recent Android releases.

Native serial port improvements (SerialPort.c):
	•	Added missing ioctl and errno includes for better portability and diagnostics
	•	Improved error checking and logging for TCGETS2 / TCSETS2
	•	Enforced RAW mode and deterministic VMIN / VTIME behavior
	•	Fixed software flow control configuration (moved IXON/IXOFF/IXANY to c_iflag)
	•	Added cold-boot robustness:
	•	Flush input/output buffers on open
	•	Optional DTR/RTS toggle to wake or reset certain UART-attached modules
	•	General cleanup and validation of baud rate, data bits, parity, stop bits, and flow control handling

No functional API changes were made.